### PR TITLE
#7 fix: correct swipeable button animation origin and text color 

### DIFF
--- a/Sources/Dodada/Delivery/Molecules/PhoneInput/DDDPhoneNumberView.swift
+++ b/Sources/Dodada/Delivery/Molecules/PhoneInput/DDDPhoneNumberView.swift
@@ -164,7 +164,7 @@ public extension DDDPhoneNumberView {
         countryCode: Binding<String>,
         isRequired: Bool = false,
         requiredMessage: String? = nil,
-        state: InputState = .default,
+        state: InputState = .default
     ) {
         self.labelText = label
         self.placeHolder = placeholder


### PR DESCRIPTION
##🔧 Cambios realizados
-✅ Modificado backgroundLayer para usar Capsule y offset, logrando que la animación nazca desde el centro hacia afuera.

-✅ Función implementada smoothTextColor() para interpolar el color del texto (Negro → Gris → Blanco) gradualmente.

-✅ Corregido bug en rightSection para que el texto reaccione correctamente al swipe positivo (dragOffset > 0).

-✅ Actualizados leftSection y rightSection para consumir el nuevo cálculo de color dinámico en lugar de la lógica booleana anterior.

Closes qbklabs/ios-aquisito#7

https://github.com/user-attachments/assets/0bc34dfa-581b-430a-a26a-6661599c35bc

